### PR TITLE
Fix content_type property

### DIFF
--- a/src/Monolog/Handler/AmqpHandler.php
+++ b/src/Monolog/Handler/AmqpHandler.php
@@ -65,7 +65,7 @@ class AmqpHandler extends AbstractProcessingHandler
                 0,
                 array(
                     'delivery_mode' => 2,
-                    'Content-type' => 'application/json',
+                    'content_type' => 'application/json',
                 )
             );
         } else {

--- a/tests/Monolog/Handler/AmqpHandlerTest.php
+++ b/tests/Monolog/Handler/AmqpHandlerTest.php
@@ -65,7 +65,7 @@ class AmqpHandlerTest extends TestCase
             0,
             array(
                 'delivery_mode' => 2,
-                'Content-type' => 'application/json',
+                'content_type' => 'application/json',
             ),
         );
 


### PR DESCRIPTION
The property "Content-type" does not exist. Use "content_type" instead.

Work for RabbitMQ.